### PR TITLE
Fixed css var mapping

### DIFF
--- a/src/frontend/nuxt.config.js
+++ b/src/frontend/nuxt.config.js
@@ -105,10 +105,10 @@ export default {
     vuetify: {
         customVariables: ['~/assets/variables.scss'],
         treeShake: true,
-        options: {
-            customProperties: true, // Maps all theme colors to css variables (i.e. background: var(--v-primary-base);)
-        },
         theme: {
+            options: {
+                customProperties: true, // Maps all theme colors to css variables (i.e. background: var(--v-primary-base);)
+            },
             themes: {
                 light: {
                     primary: '#5b8c5a',


### PR DESCRIPTION

# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
I accidentally nested the custom properties theme config into the wrong object. Anyways, small fix. Sorry bout it


# Hand testing
- [ ] You don't have to but if you want you can try to use `var(--v-primary-base)` in some css and see if that color is recognized. I did it and it works so it should be good to go.



# Checklist
- [x] Code review by me 
- [x] New code covered by automated tests
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] Ready to merge

