### PR TITLE
Optional Chaining Support

### DIFF
--- a/src/frontend/nuxt.config.js
+++ b/src/frontend/nuxt.config.js
@@ -136,6 +136,11 @@ export default {
         extend(config, ctx) {
         },
         publicPath: '/static/',
+        babel: {
+            plugins: [
+                '@babel/plugin-proposal-optional-chaining'
+            ]
+        },
         plugins: [
             new webpack.ProvidePlugin({
                 '_': 'lodash'

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -24,6 +24,7 @@
         "stylus-loader": "4"
     },
     "devDependencies": {
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
         "@nuxt/types": "^2.15.3",
         "@testing-library/vue": "^5.6.1",
         "eslint": "^7.22.0",


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 


# A brief description of the purpose of the changes contained in this PR.
Added optional chaining support (es2020 shiz). https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining


# Hand testing
- [ ] Make sure review app doesn't fail upon login

I'll hand test thoroughly but if you want...
- [ ] Add the following codeblock on login page:
```            
const obj = {}
console.log(obj.title?.name)
```
- [ ] This will cause a runtime error on the page if haven't run yarn recently.
- [ ] Now run `docker-compose exec builder yarn` to install new deps
- [ ] Reload that page and it shouldn't error out, but rather print 'undefined' in the console.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Deploy to Heroku is working
- [x] Ready to merge
