### PR TITLE
Prevent attempts to server-side render by default in Nuxt.

### DIFF
--- a/src/frontend/nuxt.config.js
+++ b/src/frontend/nuxt.config.js
@@ -14,6 +14,7 @@ export const getBrowserBaseURL = () => {
 }
 
 export default {
+  ssr: false,
   /*
   ** Headers of the page
   */


### PR DESCRIPTION
# @ mention of reviewers
@ckcollab 

# A brief description of the purpose of the changes contained in this PR.
Title says it all.

# Misc. comments
[Nuxt docs](https://nuxtjs.org/docs/configuration-glossary/configuration-ssr) say to use `ssr: false` rather than `mode: 'spa'`. See deprecation note at bottom of the following image.
![image](https://user-images.githubusercontent.com/21694127/135692121-476e90ee-23d6-458c-9cf9-514f6798c2ee.png)




# Checklist
- [x] Code review by me 
- [x] New code covered by automated tests
- [x] I'm proud of my work
- [x] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] Ready to merge

