### PR TITLE
Utilize correct staticfile serving pattern for development

### DIFF
--- a/src/backend/urls.py
+++ b/src/backend/urls.py
@@ -32,7 +32,8 @@ urlpatterns = [
 
 if settings.DEBUG:  # pragma: no cover
     # Static files for local dev, so we don't have to collectstatic and such
-    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_URL)
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
     # Django debug toolbar
     import debug_toolbar


### PR DESCRIPTION
# @ mention of reviewers
@eric


# A brief description of the purpose of the changes contained in this PR.
@elitrefts0012 and I found this while working on MacroAir, when media files weren't working. The `document_root` kwarg should point to a `ROOT` file rather than a `URL`.


# Checklist
- [x] Code review by me 
- [ ] New code covered by automated tests
- [ ] I'm proud of my work
- [x] Code review by reviewer
- [ ] Hand tested by reviewer
- [x] Ready to merge

