### PR TITLE
fix: fixing theme being ignored by nuxt

### DIFF
--- a/src/frontend/nuxt.config.ts
+++ b/src/frontend/nuxt.config.ts
@@ -17,7 +17,14 @@ export default defineNuxtConfig({
     },
 
     // import styles
-    css: ["@/assets/main.scss", "@/assets/stylus/index.styl"],
+    css: [
+        "vuetify/lib/styles/main.sass",
+        "@/assets/main.scss",
+        "@/assets/stylus/index.styl"
+    ],
+    build: {
+        transpile: ["vuetify"]
+    },
     // enable takeover mode
     typescript: {shim: false},
     pinia: {
@@ -27,10 +34,19 @@ export default defineNuxtConfig({
             ['defineStore', 'definePiniaStore'], // import { defineStore as definePiniaStore } from 'pinia'
         ],
     },
+        // 'vuetify-nuxt-module',
     modules: [
         '@pinia/nuxt',
         '@vueuse/nuxt',
-        'vuetify-nuxt-module'
+
+        // Vuetify
+        async (options, nuxt) => {
+            nuxt.hooks.hook("vite:extendConfig", (config) =>
+                // @ts-ignore
+                config.plugins.push(vuetify())
+            );
+        },
+
     ],
     app: {
         head: {


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Finally fixed this theme config 🎉 . For some reason our nuxt config was messed up.

# Hand testing
- [x] Go to `themes.ts` file and change the primary color under the light theme from `ckcColors.purple[600]`  to `#ff0000`
- [x] Go to the login page and you should see these two links as red instead of the standard purple:
<img width="356" alt="Screen Shot 2023-09-27 at 11 49 25 AM" src="https://github.com/ckc-org/skeletor/assets/27198821/0f50c401-22ad-4afe-bb4f-787b6c44d813">



# Checklist
- [x] Code review by me
- [ ] New code covered by automated tests
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
