### PR TITLE
Password Reset (again?!)

### DIFF
--- a/src/backend/settings/base.py
+++ b/src/backend/settings/base.py
@@ -33,6 +33,7 @@ USE_X_FORWARDED_HOST = True
 SITE_ID = 1
 
 SITE_DOMAIN = os.environ.get('SITE_DOMAIN', 'http://localhost:8000')
+FRONTEND_URL = os.environ.get('FRONTEND_URL', 'http://localhost:3000')
 
 THIRD_PARTY_APPS = (
     'django.contrib.sites',
@@ -210,6 +211,7 @@ ANYMAIL = {
 DEFAULT_EMAIL_CONTEXT = {
     'CURRENT_YEAR': datetime.datetime.now().year,
     'SITE_DOMAIN': SITE_DOMAIN,
+    'FRONTEND_URL': FRONTEND_URL,
     'DEFAULT_FROM_EMAIL': DEFAULT_FROM_EMAIL,
 
     # Keys prepended with IMAGE_ are replaced with InlineImages when generating emails

--- a/src/backend/templates/emails/password_reset.html
+++ b/src/backend/templates/emails/password_reset.html
@@ -23,7 +23,7 @@
         </tr>
         <tr>
             <td>
-                <a href="{{ FRONTEND_URL }}/password-reset/confirm/{{ uid }}/{{ token }}/" class="button">
+                <a href="{{ FRONTEND_URL }}/reset-password/confirm/{{ uid }}/{{ token }}/" class="button">
                     Reset my password
                 </a>
             </td>

--- a/src/backend/templates/emails/password_reset.html
+++ b/src/backend/templates/emails/password_reset.html
@@ -23,7 +23,7 @@
         </tr>
         <tr>
             <td>
-                <a href="{{ SITE_DOMAIN }}/password-reset-confirm/{{ uid }}/{{ token }}/" class="button">
+                <a href="{{ FRONTEND_URL }}/password-reset/confirm/{{ uid }}/{{ token }}/" class="button">
                     Reset my password
                 </a>
             </td>

--- a/src/backend/tests/integration/test_password_reset.py
+++ b/src/backend/tests/integration/test_password_reset.py
@@ -22,7 +22,7 @@ class TestUserPasswordReset(CkcAPITestCase):
         assert len(mail.outbox) == 1
 
         # Open up the email and find the link to our frontend, to snag uid + token
-        pattern = re.compile(r'.*password-reset-confirm/(?P<uid>.*?)/(?P<token>.*?)/', re.MULTILINE | re.DOTALL)
+        pattern = re.compile(r'.*reset-password/confirm/(?P<uid>.*?)/(?P<token>.*?)/', re.MULTILINE | re.DOTALL)
         result = pattern.match(mail.outbox[0].body).groupdict()
         uid = result["uid"]
         token = result["token"]

--- a/src/frontend/pages/reset-password/confirm/[uid]/[token].vue
+++ b/src/frontend/pages/reset-password/confirm/[uid]/[token].vue
@@ -1,0 +1,78 @@
+<template>
+  <h1>Confirm password</h1>
+
+  <p class="text-medium-emphasis">Welcome back! Let's get started</p>
+
+  <v-alert v-if="errors.non_field_errors" type="error">
+    <ul>
+      <li v-for="(error, index) in errors.non_field_errors" :key="index">{{ error }}</li>
+    </ul>
+  </v-alert>
+
+  <VForm @submit.prevent="submit" class="mt-7">
+    <div class="mt-1">
+      <label class="label text-grey-darken-2" for="email">New password</label>
+      <VTextField
+        v-model="new_password_1"
+        name="new_password_1"
+        type="password"
+        :error-messages="errors.new_password_1"
+        :error="!!errors.new_password_1"
+      />
+    </div>
+
+    <div class="mt-1">
+      <label class="label text-grey-darken-2" for="email">Confirm new password</label>
+      <VTextField
+        v-model="new_password_2"
+        name="new_password_2"
+        type="password"
+        :error-messages="errors.new_password_2"
+        :error="!!errors.new_password_1"
+      />
+    </div>
+
+    <div class="mt-5">
+      <VBtn type="submit" block min-height="44px" color="primary">
+        Set new password
+      </VBtn>
+    </div>
+  </VForm>
+</template>
+
+<script setup lang="ts">
+import {useRequest} from '~/composables/useRequest'
+import {useRoute} from '#app'
+
+definePageMeta({
+  layout: "auth",
+});
+
+
+const new_password_1 = ref("");
+const new_password_2 = ref("");
+
+const errors = ref({})
+
+const route = useRoute()
+
+
+const submit = async () => {
+  const uid = route.params.uid
+  const token = route.params.token
+
+  const {error} = await useRequest<any>(`/passwordreset/confirm/${uid}/${token}/`, {
+    method: "POST",
+    body: JSON.stringify({
+      new_password_1: new_password_1.value,
+      new_password_2: new_password_2.value,
+    }),
+  })
+
+  if (error) {
+    errors.value = error.value?.data
+  } else {
+    errors.value = {}
+  }
+};
+</script>

--- a/src/frontend/pages/reset-password/index.vue
+++ b/src/frontend/pages/reset-password/index.vue
@@ -15,7 +15,7 @@
       />
     </div>
     <div class="mt-5">
-      <VBtn type="submit" block min-height="44px" color="primary">
+      <VBtn type="submit" block min-height="44px" color="primary" @click="reset_password">
         Send instructions
       </VBtn>
     </div>
@@ -24,7 +24,8 @@
     <span
     >Don't have an account?
       <NuxtLink to="/signup" class="font-weight-bold text-primary"
-      >Sign Up
+      >
+        Sign Up
       </NuxtLink
       >
     </span
@@ -43,5 +44,17 @@ const password = ref("");
 const {ruleEmail, rulePassLen, ruleRequired} = useFormRules();
 
 const submit = async () => {
+  try {
+
+    const res = await useRequest<any>("/passwordreset/", {
+      method: "POST",
+      body: JSON.stringify({
+        email: email.value,
+      }),
+    });
+
+  } catch (e) {
+    console.error(e)
+  }
 };
 </script>


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Adds some missing password reset functionality


# Hand testing
- [ ] do password reset via frontend
- [ ] note the URL in the `docker-compose logs -f django` console email
- [ ] does that URL work to reset password?

# TODO:
- [ ] Make redirect after initial password reset request, or show some kind of nice message
- [ ] Redirect to login after successful password reset confirm


# Checklist
- [ ] Code review by me
- [ ] New code covered by automated tests
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge
